### PR TITLE
transpiling 3rd level sub-directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "scripts": {
         "build": "npm run build:init && npm run build:js && npm run build:install",
         "build:init": "rm -rf dist && mkdir dist",
-        "build:js": "cd src && babel *.js **/*.js -d ../dist",
+        "build:js": "cd src && babel *.js **/*.js **/**/*.js -d ../dist",
         "build:install": "cp package.json dist/ && cd dist && npm install --production",
         "package": "npm run build && npm run package:pack",
         "package:pack": "rm -f artifact.zip && cd dist/ && zip -r ../artifact.zip *"


### PR DESCRIPTION
I'm not sure why, but `**/*.js` was not enough for me to transpile third level sub-directories. I had to add `**/**/*.js` for this to work.